### PR TITLE
throw fatal if not enough sysadmins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@ users Cookbook CHANGELOG
 ========================
 This file is used to list changes made in each version of the users cookbook.
 
-UNRELEASED (v1.8.3)
+v1.8.3 (2015-10-22)
 -------------------
+- Fatal if not enough sysadmins
 
 v1.8.2 (2015-03-18)
 -------------------
@@ -11,16 +12,16 @@ v1.8.2 (2015-03-18)
 
 v1.8.1 (2015-03-12)
 -------------------
-- Add `source_url` and `issues_url` to the metadata.rb so Supermarket can display 
+- Add `source_url` and `issues_url` to the metadata.rb so Supermarket can display
 appropriate links
 
 v1.8.0 (2015-03-09)
 -------------------
 - Expose LWRP state attributes
 - [COOK-4401] - Add unit tests with ChefSpec
-- [COOK-4404] - Determine file system and add manage_nfs_home_dirs attribute to disable 
+- [COOK-4404] - Determine file system and add manage_nfs_home_dirs attribute to disable
 managing NFS mounted home directories
-- Remove `converge_by` when creating home directory, the directory resource 
+- Remove `converge_by` when creating home directory, the directory resource
 already handles this
 - Do not manage home directory if the path does not exist
 - Add integration with TravisCI

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license          'Apache 2.0'
 description      'Creates users from a databag search'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.8.3'
+version          '1.8.4'
 
 recipe           'users::default', 'Empty recipe for including LWRPs'
 recipe           'users::sysadmins', 'Create and manage sysadmin group'

--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -49,7 +49,11 @@ action :create do
   if Chef::Config[:solo] && !chef_solo_search_installed?
     Chef::Log.warn('This recipe uses search. Chef Solo does not support search unless you install the chef-solo-search cookbook.')
   else
-    search(new_resource.data_bag, "groups:#{new_resource.search_group} AND NOT action:remove") do |u|
+    users = search(new_resource.data_bag, "groups:#{new_resource.search_group} AND NOT action:remove")
+    if users.length < 5 && new_resource.search_group == 'sysadmin'
+      Chef::Log.fatal!("Not enough sysadmins (#{users.length}). Is search broken?")
+    end
+    users do |u|
       u['username'] ||= u['id']
       security_group << u['username']
 


### PR DESCRIPTION
@optimizely/data-services I'll remove the magic number and put it into a constant, but this should protect us against deleting all our sysadmins
